### PR TITLE
feat: Added a feature flag supporting Defender for Cloud Continuous Export

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -21,7 +21,7 @@ data "azurerm_key_vault_key" "cmk_encryption_key" {
 }
 
 data "azurerm_storage_account" "this" {
-  depends_on = [ module.storage_account ]
+  depends_on          = [module.storage_account]
   name                = var.storage_account.name
   resource_group_name = var.resource_group_name
 }

--- a/eventHubNamespace.tf
+++ b/eventHubNamespace.tf
@@ -17,6 +17,15 @@ resource "azurerm_role_assignment" "ehns_datadog_mid" {
   skip_service_principal_aad_check = false
 }
 
+resource "azurerm_role_assignment" "security_provider" {
+  count  = var.support_defender_export != null ? 1 : 0
+
+  principal_id                     = "ba468016-bfd0-4042-a934-c2012278a59e" # Windows Azure Security Resource Provider
+  scope                            = resource.azurerm_eventhub_namespace.this.id
+  role_definition_name             = "Azure Event Hubs Data Sender"
+  skip_service_principal_aad_check = false
+}
+
 resource "azurerm_eventhub_namespace" "this" {
   location                      = var.location
   resource_group_name           = var.resource_group_name

--- a/eventHubNamespace.tf
+++ b/eventHubNamespace.tf
@@ -18,7 +18,7 @@ resource "azurerm_role_assignment" "ehns_datadog_mid" {
 }
 
 resource "azurerm_role_assignment" "security_provider" {
-  count  = var.support_defender_export != null ? 1 : 0
+  count = var.support_defender_export != null ? 1 : 0
 
   principal_id                     = "ba468016-bfd0-4042-a934-c2012278a59e" # Windows Azure Security Resource Provider
   scope                            = resource.azurerm_eventhub_namespace.this.id

--- a/functionApp.tf
+++ b/functionApp.tf
@@ -53,18 +53,18 @@ resource "azurerm_role_assignment" "func_datadog_mid_eventhub" {
 }
 
 resource "azurerm_linux_function_app" "this" {
-  depends_on                                      = [ module.storage_account, azurerm_role_assignment.func_datadog_mid_sta_file, azurerm_role_assignment.func_datadog_mid_sta_queue, azurerm_role_assignment.func_datadog_mid_sta_table, azurerm_role_assignment.func_datadog_mid_keyvault ]
-  location                                        = var.location
-  resource_group_name                             = var.resource_group_name
-  name                                            = var.function_app_name
-  service_plan_id                                 = var.function_app.service_plan_id
-  virtual_network_subnet_id                       = var.function_app.vnet_subnet_id
-  storage_account_name                            = module.storage_account.name
-  storage_uses_managed_identity                   = true
-  ftp_publish_basic_authentication_enabled        = false
-  webdeploy_publish_basic_authentication_enabled  = false
-  public_network_access_enabled                   = false
-  https_only                                      = true
+  depends_on                                     = [module.storage_account, azurerm_role_assignment.func_datadog_mid_sta_file, azurerm_role_assignment.func_datadog_mid_sta_queue, azurerm_role_assignment.func_datadog_mid_sta_table, azurerm_role_assignment.func_datadog_mid_keyvault]
+  location                                       = var.location
+  resource_group_name                            = var.resource_group_name
+  name                                           = var.function_app_name
+  service_plan_id                                = var.function_app.service_plan_id
+  virtual_network_subnet_id                      = var.function_app.vnet_subnet_id
+  storage_account_name                           = module.storage_account.name
+  storage_uses_managed_identity                  = true
+  ftp_publish_basic_authentication_enabled       = false
+  webdeploy_publish_basic_authentication_enabled = false
+  public_network_access_enabled                  = false
+  https_only                                     = true
   identity {
     type         = "UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.func_datadog_mid.id]
@@ -88,24 +88,24 @@ resource "azurerm_linux_function_app" "this" {
     "FUNCTIONS_EXTENSION_VERSION"         = "~4"
   }
   site_config {
-    always_on                               = false
-    http2_enabled                           = true
-    ftps_state                              = "Disabled"
-    minimum_tls_version                     = "1.3"
-    application_insights_connection_string  = azurerm_application_insights.appr_appi.connection_string
-    application_insights_key                = azurerm_application_insights.appr_appi.instrumentation_key
-    application_stack{
-      node_version                          = "20" 
+    always_on                              = false
+    http2_enabled                          = true
+    ftps_state                             = "Disabled"
+    minimum_tls_version                    = "1.3"
+    application_insights_connection_string = azurerm_application_insights.appr_appi.connection_string
+    application_insights_key               = azurerm_application_insights.appr_appi.instrumentation_key
+    application_stack {
+      node_version = "20"
     }
   }
-  
+
 
   storage_account {
     account_name = module.storage_account.name
-    name = module.storage_account.name
-    type = "AzureBlob"
-    share_name = "functionapp"
-    access_key = module.storage_account.access_keys.primary
+    name         = module.storage_account.name
+    type         = "AzureBlob"
+    share_name   = "functionapp"
+    access_key   = module.storage_account.access_keys.primary
   }
   tags = merge(
     try(var.tags),

--- a/storageAccount.tf
+++ b/storageAccount.tf
@@ -19,8 +19,8 @@ resource "azurerm_role_assignment" "sta_datadog_mid" {
 
 
 module "storage_account" {
-  depends_on = [ azurerm_role_assignment.sta_datadog_mid ]
-  source = "github.com/schubergphilis/terraform-azure-mcaf-storage-account.git?ref=v0.7.2"
+  depends_on = [azurerm_role_assignment.sta_datadog_mid]
+  source     = "github.com/schubergphilis/terraform-azure-mcaf-storage-account.git?ref=v0.7.2"
 
   name                              = var.storage_account.name
   location                          = var.location
@@ -45,7 +45,7 @@ module "storage_account" {
 }
 
 resource "azurerm_storage_container" "this" {
-  for_each = var.ddog_storage_containers
+  for_each              = var.ddog_storage_containers
   name                  = each.key
   storage_account_id    = module.storage_account.id
   container_access_type = "private"

--- a/variables.tf
+++ b/variables.tf
@@ -129,3 +129,8 @@ variable "event_hub_consumer_groups" {
   description = "Event Hub consumer groups"
   type = set(string)
 }
+
+variable "support_defender_export" {
+  type        = bool
+  description = "Feature flag allowing operators to enable support For Defender's Coninuous Export"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -118,16 +118,16 @@ variable "event_hub_authorization_rules" {
   description = "Event Hub authorization rules"
   type = map(
     object({
-      listen              = bool
-      send                = bool
-      manage              = bool
+      listen = bool
+      send   = bool
+      manage = bool
     })
   )
 }
 
 variable "event_hub_consumer_groups" {
   description = "Event Hub consumer groups"
-  type = set(string)
+  type        = set(string)
 }
 
 variable "support_defender_export" {


### PR DESCRIPTION
💡 Summary of the pull request
Added support for Defender for Cloud Continuous Export to the Event Hub

🛠️ Implementation Details
Added an RBAC assignment granting the "Windows Azure Security Resource Provider"  Enterprise Application the "Azure Event Hubs Data Sender" RBAC role scoped to the Event Hub. This assignment allows the Defender for Cloud to continuously export data using the Event Hub Namespace. 
The RBAC assignment is controlled by a variable which acts as a feature flag. 

📝 Additional Information
Following https://learn.microsoft.com/en-us/azure/defender-for-cloud/continuous-export-event-hub-firewall
