### PR TITLE
Bug: security_provider role assignment deployed when var is set to false

### DIFF
--- a/eventHubNamespace.tf
+++ b/eventHubNamespace.tf
@@ -18,7 +18,7 @@ resource "azurerm_role_assignment" "ehns_datadog_mid" {
 }
 
 resource "azurerm_role_assignment" "security_provider" {
-  count = var.support_defender_export != null ? 1 : 0
+  count = var.support_defender_export ? 1 : 0
 
   principal_id                     = "ba468016-bfd0-4042-a934-c2012278a59e" # Windows Azure Security Resource Provider
   scope                            = resource.azurerm_eventhub_namespace.this.id


### PR DESCRIPTION
azurerm_role_assignment "security_provider" deployed wether var.support_defender_export was set to "True" or "False" 

Fixed by removing != null 