### PR TITLE
breaking: Route outbound traffic through vnet, fix app insights settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 2.53.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.0.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 2.53 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.0 |
 
 ## Modules
 
@@ -65,6 +65,7 @@
 | <a name="input_function_app"></a> [function\_app](#input\_function\_app) | The parameters to be used for the Function App deployment. Inludes the ID of the App Service Plan to be used and the ID of the subent for regional VNET integration | <pre>object({<br/>    service_plan_id = string<br/>    vnet_subnet_id  = string<br/>  })</pre> | n/a | yes |
 | <a name="input_function_app_name"></a> [function\_app\_name](#input\_function\_app\_name) | The name of the Function App to be deployed | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | Location of the deployed Resources | `string` | n/a | yes |
+| <a name="input_log_analytics_workspace_id"></a> [log\_analytics\_workspace\_id](#input\_log\_analytics\_workspace\_id) | The resource id of the log analytics workspace to which application insights logs should be sent | `string` | n/a | yes |
 | <a name="input_managed_identity_name"></a> [managed\_identity\_name](#input\_managed\_identity\_name) | The name of the Managed Identity to be deployed | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The Resource Group that will be used the deployment | `string` | n/a | yes |
 | <a name="input_datadog_site_hostname"></a> [datadog\_site\_hostname](#input\_datadog\_site\_hostname) | Datadog site host name | `string` | `"datadoghq.eu"` | no |

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -31,6 +31,8 @@ module "datadog_forwarder" {
   application_insights_name = "example-datadog-insights"
   managed_identity_name     = "datadog-mid"
 
+  log_analytics_workspace_id = "/resource/path/to/log-analytics-workspace"
+
   event_hub = {
     namespace_name     = "example-datadog-evhns"
     hub_name           = "example-datadog-evh"

--- a/functionApp.tf
+++ b/functionApp.tf
@@ -94,6 +94,7 @@ resource "azurerm_linux_function_app" "this" {
     minimum_tls_version                    = "1.3"
     application_insights_connection_string = azurerm_application_insights.appr_appi.connection_string
     application_insights_key               = azurerm_application_insights.appr_appi.instrumentation_key
+    vnet_route_all_enabled                 = true
     application_stack {
       node_version = "20"
     }

--- a/functionApp.tf
+++ b/functionApp.tf
@@ -128,4 +128,8 @@ resource "azurerm_application_insights" "appr_appi" {
       "Resource Type" = "Application Insights"
     })
   )
+  workspace_id = var.log_analytics_workspace_id
+
+  internet_ingestion_enabled = false
+  internet_query_enabled     = false
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,15 +4,15 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4"
+      version = "~> 4.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.53.1"
+      version = "~> 2.53"
     }
     datadog = {
       source  = "datadog/datadog"
-      version = ">= 3.0.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -135,3 +135,8 @@ variable "support_defender_export" {
   description = "Feature flag allowing operators to enable support For Defender's Coninuous Export"
   default     = false
 }
+
+variable "log_analytics_workspace_id" {
+  type = string
+  description = "The resource id of the log analytics workspace to which application insights logs should be sent"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -137,6 +137,6 @@ variable "support_defender_export" {
 }
 
 variable "log_analytics_workspace_id" {
-  type = string
+  type        = string
   description = "The resource id of the log analytics workspace to which application insights logs should be sent"
 }


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
Ensure that outbound internet traffic is routed through the VNET.
Fixes settings on the log analytics workspace and allows configuring its log analytics workspace

**:rocket: Motivation**
Improves network security and removes need for automatically create log analytics workspaces from app insights
