### PR TITLE
up node_version to 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | ~> 3.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.58 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.58 |
 
 ## Modules
 

--- a/functionApp.tf
+++ b/functionApp.tf
@@ -91,7 +91,7 @@ resource "azurerm_linux_function_app" "this" {
     application_insights_key               = azurerm_application_insights.appr_appi.instrumentation_key
     vnet_route_all_enabled                 = true
     application_stack {
-      node_version = "20"
+      node_version = "24"
     }
   }
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 4.58"
     }
     datadog = {
       source  = "datadog/datadog"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
- Set NodeJS version for the function app to NodeJS 24
- Update minimum provider version for AzureRM to support NodeJS 24
- Updated the Datadog provider version to be in line with the latest major version

**:rocket: Motivation**
Microsoft is ending support for NodeJS 20 for function apps.
